### PR TITLE
ssho-lab/ssho-issue-board#26 상품 태깅 조회 UI 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+debug.log*

--- a/src/admin/pages/AdminPage.css
+++ b/src/admin/pages/AdminPage.css
@@ -13,3 +13,7 @@
 .header {
     text-align: right;
 }
+
+.option-label-item{
+    margin-right: 6px;
+}

--- a/src/admin/pages/AdminPage.tsx
+++ b/src/admin/pages/AdminPage.tsx
@@ -56,7 +56,7 @@ const AdminPage: React.FC<AdminPageProps> = () => {
     }
 
     const getAllTagList = () => {
-        axios.get('http://3.35.129.79:8080'+'/tag')
+        axios.get('http://3.35.129.79:8080/tag')
             .then(function(response: any){
                 setAllTagList(response.data)
             })

--- a/src/admin/pages/AdminPage.tsx
+++ b/src/admin/pages/AdminPage.tsx
@@ -10,7 +10,7 @@ import UserDashboardPage from "./user/UserDashboardPage";
 import SubMenu from "antd/es/menu/SubMenu";
 import API_ENDPOINTS from '../../endpoints';
 
-const { Header, Content, Footer, Sider } = Layout;
+const { Header, Content, Sider } = Layout;
 
 interface AdminPageProps {}
 
@@ -20,6 +20,7 @@ const AdminPage: React.FC<AdminPageProps> = () => {
     const [ itemList, setItemList ] = useState<any>([])
     const [ swipeLogList, setSwipeLogList ] = useState<any>([])
     const [ userList, setUserList ] = useState<any>([])
+    const [ allTagList, setAllTagList] = useState<any>([])
 
     const {history} = useReactRouter()
 
@@ -54,6 +55,16 @@ const AdminPage: React.FC<AdminPageProps> = () => {
             })
     }
 
+    const getAllTagList = () => {
+        axios.get('http://3.35.129.79:8080'+'/tag')
+            .then(function(response: any){
+                setAllTagList(response.data)
+            })
+
+            .catch(function(err){
+            })
+    }
+
     useEffect(()=>{
         if (sessionStorage.getItem('token') === null ||
             sessionStorage.getItem('admin') === null ||
@@ -64,6 +75,7 @@ const AdminPage: React.FC<AdminPageProps> = () => {
         getItemList()
         getSwipeLogList()
         getUserList()
+        getAllTagList()
     },[])
 
     return (
@@ -102,7 +114,7 @@ const AdminPage: React.FC<AdminPageProps> = () => {
                 <Header className="site-layout-background" style={{ padding: 0 }} />
                 <Content style={{ margin: '24px 0 0', overflow: 'initial', height: "100vh"}}>
                     <div className="site-layout-background" style={{ padding: 24, textAlign: 'center' }}>
-                        {menuId === 0 && itemList && <ItemDashboardPage dataSource={itemList}/>}
+                        {menuId === 0 && itemList && <ItemDashboardPage dataSource={itemList} allTagList={allTagList}/>}
                         {menuId === 1 && swipeLogList && <SwipeLogDashboardPage dataSource={swipeLogList}/>}
                         {menuId === 2 && userList && <UserDashboardPage dataSource={userList}/>}
                     </div>

--- a/src/admin/pages/item/ItemDashboardPage.tsx
+++ b/src/admin/pages/item/ItemDashboardPage.tsx
@@ -62,7 +62,7 @@ const ItemDashboardPage: React.FC<ItemDashboardPageProps> = ({dataSource, allTag
         {
             title: '태그 리스트',
             dataIndex: 'tagList',
-            render: (tagList: TagProps[]) => <TagList tagListPerItem={tagList} allTagList={allTagList}/>,
+            render: (tagList: TagProps[], record: any) => <TagList itemId={record.id} tagListPerItem={tagList} allTagList={allTagList}/>,
         },
         {
             title: '가격',

--- a/src/admin/pages/item/ItemDashboardPage.tsx
+++ b/src/admin/pages/item/ItemDashboardPage.tsx
@@ -84,7 +84,7 @@ const ItemDashboardPage: React.FC<ItemDashboardPageProps> = ({dataSource, allTag
     ];
 
     return (
-        <Table columns={columns} dataSource={dataSource} pagination={{ pageSize: 50 }} scroll={{ y: 320 }} />
+        <Table columns={columns} rowKey={record => record.id} dataSource={dataSource} pagination={{ pageSize: 50 }} scroll={{ y: 320 }} />
     )
 }
 

--- a/src/admin/pages/item/ItemDashboardPage.tsx
+++ b/src/admin/pages/item/ItemDashboardPage.tsx
@@ -1,14 +1,24 @@
 import * as React from 'react';
-import {Button, Layout, Table} from "antd";
-
-const { Header, Content, Footer, Sider } = Layout;
+import {Button, Table} from "antd";
+import TagList from './TagList';
 
 interface ItemDashboardPageProps {
-    dataSource: []
+    dataSource: [];
+    allTagList: [];
 }
 
-const ItemDashboardPage: React.FC<ItemDashboardPageProps> = ({dataSource}) => {
+interface Tag{
+  id: string;
+  name: string;
+  embedding?: null;
+}
 
+interface TagProps{
+  expTag: Tag;
+  realTagList: Tag[];
+}
+
+const ItemDashboardPage: React.FC<ItemDashboardPageProps> = ({dataSource, allTagList}) => {
     const columns = [
         {
             title: '상품 고유 번호',
@@ -47,6 +57,12 @@ const ItemDashboardPage: React.FC<ItemDashboardPageProps> = ({dataSource}) => {
         {
             title: '상품명',
             dataIndex: 'title',
+            width: 150,
+        },
+        {
+            title: '태그 리스트',
+            dataIndex: 'tagList',
+            render: (tagList: TagProps[]) => <TagList tagListPerItem={tagList} allTagList={allTagList}/>,
         },
         {
             title: '가격',

--- a/src/admin/pages/item/TagList.tsx
+++ b/src/admin/pages/item/TagList.tsx
@@ -1,5 +1,8 @@
 import React, {useState} from 'react';
-import {Select, Button} from 'antd';
+import {Select, Button, message} from 'antd';
+import axios from 'axios';
+import API_ENDPOINTS from '../../../endpoints';
+
 const {Option, OptGroup} = Select;
 
 interface Tag{
@@ -16,35 +19,62 @@ interface TagProps{
 interface TagListProps{
   tagListPerItem: TagProps[];
   allTagList: TagProps[];
+  itemId: string;
 }
 
+const updateTag = (itemId: string, data: any) => {
+  return axios.post(API_ENDPOINTS.ITEM_API+'/item/update/tag',data, {
+    params:{
+      itemId
+    }
+  })
+}
 
-  
-const TagList = ({tagListPerItem, allTagList}: TagListProps) => {
-  const realTagList = tagListPerItem && Array.from(new Set<string>(tagListPerItem.map(el => el.realTagList).flat().map(tag=>tag.name)));
-
+const TagList = ({itemId, tagListPerItem, allTagList}: TagListProps) => {
+  let defaultTagList = tagListPerItem && Array.from(new Set<string>(tagListPerItem.map(el => el.realTagList).flat().map(tag=> tag.name)))
   const options= allTagList.map(el => {
     return (
       <OptGroup label={el.expTag.name}>
-        {el.realTagList.map(realTag => <Option value={realTag.name}>{realTag.name}</Option>)}
+        {el.realTagList.map(realTag => <Option label={el.expTag.name} value={realTag.name}>{realTag.name}</Option>)}
       </OptGroup>
     )
   })
 
   const [buttonClickable, setButtonClickable] = useState<boolean>(false);
+  const [expTagList, setExpTagList] = useState<string[]>([]);
+  const [realTagList, setRealTagList] = useState<string[]>([]);
 
-  const handleSelectChange = (selected: string[]) => {
-    if(JSON.stringify(selected.sort()) === JSON.stringify(realTagList.sort())){
+  const handleSelectChange = (selected: string[], options: any) => {
+    setExpTagList(Array.from(new Set<string>(options.map((option: any) => option.label))));
+    setRealTagList(options.map((option: any) => option.value));
+
+    if(JSON.stringify(selected.sort()) === JSON.stringify(defaultTagList.sort())){
       setButtonClickable(false);
       return;
     }
     setButtonClickable(true);
   }
 
+  const handleClick = () => {
+    let newTagList = allTagList.filter(el => expTagList.includes(el.expTag.name));
+    newTagList.forEach(el => el.realTagList = el.realTagList.filter(realTag => realTagList.includes(realTag.name)));
+
+
+    updateTag(itemId, newTagList)
+      .then(function (response: any) {
+        message.success('태그 수정 완료');
+        setButtonClickable(false);
+        defaultTagList = [...realTagList];
+      })
+      .catch(function (err){
+        message.error('태그 수정 실패');
+      })
+  }
+
   return (
     <div style={{display: 'flex'}}>
-      <Select mode="multiple" defaultValue={realTagList} style={{width: '80%'}}  placeholder="태그 리스트" optionLabelProp="label" onChange={handleSelectChange}>{options}</Select>
-      <Button type="primary" style={{width: '20%'}} disabled={!buttonClickable}>태그 수정</Button>
+      <Select mode="multiple" allowClear defaultValue={defaultTagList} style={{width: '80%'}}  placeholder="태그 리스트" onChange={handleSelectChange}>{options}</Select>
+      <Button type="primary" style={{width: '20%'}} disabled={!buttonClickable} onClick={handleClick}>태그 수정</Button>
     </div>
   );
 }

--- a/src/admin/pages/item/TagList.tsx
+++ b/src/admin/pages/item/TagList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {Select} from 'antd';
+
+const {Option, OptGroup} = Select;
+
+interface Tag{
+  id: string;
+  name: string;
+  embedding?: null;
+}
+
+interface TagProps{
+  expTag: Tag;
+  realTagList: Tag[];
+}
+
+interface TagListProps{
+  tagListPerItem: TagProps[];
+  allTagList: TagProps[];
+}
+
+
+  
+const TagList = ({tagListPerItem, allTagList}: TagListProps) => {
+  const realTagList = tagListPerItem && Array.from(new Set<string>(tagListPerItem.map(el => el.realTagList).flat().map(tag=>tag.name)));
+  
+  const options= allTagList.map(el => {
+    return (
+      <OptGroup label={el.expTag.name}>
+        {el.realTagList.map(realTag => <Option value={realTag.name}>{realTag.name}</Option>)}
+      </OptGroup>
+    )
+  })
+
+  return (
+    <Select mode="multiple" defaultValue={realTagList} style={{width: '100%'}}  placeholder="태그 리스트" optionLabelProp="label">{options}</Select>
+  );
+}
+
+export default TagList;

--- a/src/admin/pages/item/TagList.tsx
+++ b/src/admin/pages/item/TagList.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import {Select} from 'antd';
-
+import React, {useState} from 'react';
+import {Select, Button} from 'antd';
 const {Option, OptGroup} = Select;
 
 interface Tag{
@@ -23,7 +22,7 @@ interface TagListProps{
   
 const TagList = ({tagListPerItem, allTagList}: TagListProps) => {
   const realTagList = tagListPerItem && Array.from(new Set<string>(tagListPerItem.map(el => el.realTagList).flat().map(tag=>tag.name)));
-  
+
   const options= allTagList.map(el => {
     return (
       <OptGroup label={el.expTag.name}>
@@ -32,8 +31,21 @@ const TagList = ({tagListPerItem, allTagList}: TagListProps) => {
     )
   })
 
+  const [buttonClickable, setButtonClickable] = useState<boolean>(false);
+
+  const handleSelectChange = (selected: string[]) => {
+    if(JSON.stringify(selected.sort()) === JSON.stringify(realTagList.sort())){
+      setButtonClickable(false);
+      return;
+    }
+    setButtonClickable(true);
+  }
+
   return (
-    <Select mode="multiple" defaultValue={realTagList} style={{width: '100%'}}  placeholder="태그 리스트" optionLabelProp="label">{options}</Select>
+    <div style={{display: 'flex'}}>
+      <Select mode="multiple" defaultValue={realTagList} style={{width: '80%'}}  placeholder="태그 리스트" optionLabelProp="label" onChange={handleSelectChange}>{options}</Select>
+      <Button type="primary" style={{width: '20%'}} disabled={!buttonClickable}>태그 수정</Button>
+    </div>
   );
 }
 

--- a/src/admin/pages/swipelog/SwipeLogDashboardPage.tsx
+++ b/src/admin/pages/swipelog/SwipeLogDashboardPage.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import {Layout, Table} from "antd";
-
-const { Header, Content, Footer, Sider } = Layout;
+import {Table} from "antd";
 
 interface SwipeLogDashboardPageProps {
     dataSource: []

--- a/src/admin/pages/user/UserDashboardPage.tsx
+++ b/src/admin/pages/user/UserDashboardPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {Layout, Menu, message, Table} from "antd";
-const { Header, Content, Footer, Sider } = Layout;
+import {Table} from "antd";
 
 interface UserDashboardPageProps {
     dataSource: []

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -1,7 +1,7 @@
 const API_ENDPOINTS = {
-    ITEM_API : 'http://api.ssho.tech:8081',
-    LOG_API : 'http://api.ssho.tech:8082'
-}
+  ITEM_API: "http://api.ssho.tech:8081",
+  LOG_API: "http://api.ssho.tech:8082",
+  TAG_API: "http://3.35.129.79:8080",
+};
 
-export default API_ENDPOINTS
-
+export default API_ENDPOINTS;

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,6 +1,7 @@
 const API_ENDPOINTS = {
     ITEM_API : 'http://api.ssho.tech:8081',
-    LOG_API : 'http://api.ssho.tech:8082'
+    LOG_API : 'http://api.ssho.tech:8082',
+    TAG_API : 'http://3.35.129.79:8080'
 }
 
 export default API_ENDPOINTS

--- a/src/home/pages/SignupPage.tsx
+++ b/src/home/pages/SignupPage.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import '../../App.css';
 import useReactRouter from 'use-react-router';
 import axios from 'axios';


### PR DESCRIPTION
* TagList.tsx 로 태그리스트 컴포넌트 분리
* ItemDashboardPage에서 TagList 조회 로직 추가
* TAG_API ENDPOINT 추가 (작동하지 않음.. 매직 string으로 url을 넣으니 작동)

현재 아래 그림과 같이 expTag-realTagList를 group화하여 렌더링해줍니다. 선택할 수 있는 태그는 realTagList입니다.
![image](https://user-images.githubusercontent.com/26531678/96631694-9e0f1780-1351-11eb-8222-49a56d675f3c.png)

원래 아래와 같이 Select에 Cascader를 혼합하려 했으나 혼합하는게 복잡해서 우선 위 UI처럼 Option들을 그룹화하여 진행했습니다.
![image](https://user-images.githubusercontent.com/26531678/96632168-491fd100-1352-11eb-9585-55030ada5bec.png)

남은 작업
* 태그 저장, 삭제 API 연동

